### PR TITLE
previous_key in cycleAction now contains modifier key flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Key_Cycle
 
 // later in the Sketch:
 void cycleAction(Key previous_key, uint8_t cycle_count) {
-  if (previous_key.raw == Key_A.raw) {
-    cycleThrough (Key_B, Key_C, Key_D);
-  }
+  bool is_shifted = previous_key.flags & SHIFT_HELD;
+  if (previous_key.keyCode == Key_A.keyCode && is_shifted)
+      cycleThrough (LSHIFT(Key_A), LSHIFT(Key_B), LSHIFT(Key_C));
+  if (previous_key.keyCode == Key_A.keyCode && !is_shifted)
+      cycleThrough (Key_A, Key_B, Key_C);
 }
 
 KALEIDOSCOPE_INIT_PLUGINS(Cycle);

--- a/src/Kaleidoscope/Cycle.cpp
+++ b/src/Kaleidoscope/Cycle.cpp
@@ -23,6 +23,7 @@
 namespace kaleidoscope {
 // --- state ---
 Key Cycle::last_non_cycle_key_;
+uint8_t Cycle::current_modifier_flags_;
 uint8_t Cycle::cycle_count_;
 
 // --- helpers ---
@@ -66,8 +67,13 @@ EventHandlerResult Cycle::onKeyswitchEvent(Key &mapped_key, byte row, byte col, 
 
   if (!isCycle(mapped_key)) {
     if (keyToggledOn(key_state)) {
-      last_non_cycle_key_.raw = mapped_key.raw;
+      current_modifier_flags_ |= toModFlag(mapped_key.keyCode);
+      last_non_cycle_key_.keyCode = mapped_key.keyCode;
+      last_non_cycle_key_.flags = current_modifier_flags_;
       cycle_count_ = 0;
+    }
+    if (keyToggledOff(key_state)) {
+      current_modifier_flags_ &= ~toModFlag(mapped_key.keyCode);
     }
     return EventHandlerResult::OK;
   }
@@ -79,6 +85,26 @@ EventHandlerResult Cycle::onKeyswitchEvent(Key &mapped_key, byte row, byte col, 
   ++cycle_count_;
   cycleAction(last_non_cycle_key_, cycle_count_);
   return EventHandlerResult::EVENT_CONSUMED;
+}
+
+uint8_t Cycle::toModFlag(uint8_t keyCode) {
+  switch (keyCode) {
+    case Key_LeftShift.keyCode:
+    case Key_RightShift.keyCode:
+      return SHIFT_HELD;
+    case Key_LeftAlt.keyCode:
+      return LALT_HELD;
+    case Key_RightAlt.keyCode:
+      return RALT_HELD;
+    case Key_LeftControl.keyCode:
+    case Key_RightControl.keyCode:
+      return CTRL_HELD;
+    case Key_LeftGui.keyCode:
+    case Key_RightGui.keyCode:
+      return GUI_HELD;
+    default:
+      return 0;
+  }
 }
 
 #if KALEIDOSCOPE_ENABLE_V1_PLUGIN_API

--- a/src/Kaleidoscope/Cycle.h
+++ b/src/Kaleidoscope/Cycle.h
@@ -49,8 +49,10 @@ class Cycle : public kaleidoscope::Plugin {
 #endif
 
  private:
+  static uint8_t toModFlag(uint8_t keyCode);
   static Key last_non_cycle_key_;
   static uint8_t cycle_count_;
+  static uint8_t current_modifier_flags_;
 };
 };
 


### PR DESCRIPTION
When trying to use the plugin to cycle through vowels and their "decorated" variants (a, ä, à, etc) i found no way to produce uppercase letters.
I hope the benefit of being able to react to modifier keys outweighs the slight change in "cycleAction"s semantics.